### PR TITLE
fix(jwtmw): pass http.Request in tokenValidator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.3
+
+[All Changes](https://github.com/crossid/crossid-go/compare/v0.0.2...v0.0.3)
+
+### Minor Changes
+
+- jwtmw - pass http.Request in tokenValidator.
+
 ## 0.0.2
 
 [All Changes](https://github.com/crossid/crossid-go/compare/v0.0.1...v0.0.2)

--- a/pkg/jwtmw/jwt.go
+++ b/pkg/jwtmw/jwt.go
@@ -50,7 +50,7 @@ func (j *JWT) Validate(r *http.Request) (*jwt.Token, error) {
 	}
 
 	if j.opts.Validate != nil {
-		if err := j.opts.Validate(pt, c); err != nil {
+		if err := j.opts.Validate(r, pt, c); err != nil {
 			return nil, ErrInvalidToken
 		}
 	}

--- a/pkg/jwtmw/jwt_test.go
+++ b/pkg/jwtmw/jwt_test.go
@@ -186,12 +186,13 @@ func TestJWT_Handler(t *testing.T) {
 			}),
 			opts: &JwtMiddlewareOpts{
 				KeyFunc: validKeyFunc,
-				Validate: func(to *jwt.Token, c jwt.Claims) error {
+				Validate: func(_ *http.Request, to *jwt.Token, c jwt.Claims) error {
 					cl := c.(jwt.MapClaims)
 					assertTrue(t, cl.VerifyIssuer("crossid.io", true), "invalid issuer")
 					assertTrue(t, !cl.VerifyAudience("foo", true), "invalid issuer")
 					assertTrue(t, cl.VerifyAudience("acme.io", true), "invalid audience")
 					assertTrue(t, !cl.VerifyAudience("foo", true), "invalid audience")
+					assertTrue(t, to.Valid, "token should be valid")
 					return nil
 				},
 			},

--- a/pkg/jwtmw/opts.go
+++ b/pkg/jwtmw/opts.go
@@ -23,7 +23,7 @@ type errorWriter func(w http.ResponseWriter, r *http.Request, err error)
 type logger func(level Level, format string, args ...interface{})
 
 // tokenValidator validates that t and c are valid.
-type tokenValidator func(t *jwt.Token, c jwt.Claims) error
+type tokenValidator func(r *http.Request, t *jwt.Token, c jwt.Claims) error
 
 // JwtMiddlewareOpts describes the options of the JWTMiddleware
 type JwtMiddlewareOpts struct {


### PR DESCRIPTION
this let the consumer more control over the token validation phase
such using request's context in order to perform token checks against a store, etc.